### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure API Gateway Throttling Limits

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -8,6 +8,26 @@ Creates an [AWS Lambda](https://aws.amazon.com/lambda/) function writing to [Ama
 
 ![architecture](docs/architecture.png)
 
+## Throttling Configuration
+
+This stack implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** to protect against resource exhaustion.
+
+### Configured Limits
+- **API Gateway Stage Throttle:**
+  - Rate Limit: 50 requests/second
+  - Burst Limit: 100 requests
+
+These limits should be adjusted based on load testing results for your specific workload.
+
+### Testing Throttling
+When throttle limits are exceeded, the API returns:
+```json
+{
+  "message": "Too Many Requests"
+}
+```
+HTTP Status: `429`
+
 ## Setup
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -105,6 +105,8 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
                 tracing_enabled=True,
+                throttling_burst_limit=100,
+                throttling_rate_limit=50,
                 access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
                 access_log_format=apigw_.AccessLogFormat.json_with_standard_fields(
                     caller=True,


### PR DESCRIPTION
## Summary

This PR implements API Gateway stage-level throttling limits to address AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes protect the API from resource exhaustion during unexpected traffic spikes, flooding attacks, or retry storms.

Fixes #5

## Changes Made

### API Gateway Throttling Configuration
- Added `throttling_burst_limit=100` to handle short-term traffic spikes
- Added `throttling_rate_limit=50` requests per second for sustained load protection
- Configured at the API Gateway stage level in `deploy_options`

### Documentation Updates
- Added "Throttling Configuration" section to README.md
- Documented configured throttle limits and their purpose
- Included guidance on testing throttling behavior (429 responses)
- Added note that limits should be adjusted based on load testing

## Well-Architected Framework Compliance

These changes implement REL05-BP02 throttling requirements, mitigating high risk of resource exhaustion. Without throttling, unexpected volume spikes could overwhelm Lambda and DynamoDB resources, causing service degradation.

✅ **Prevents Resource Exhaustion**: Throttling protects backend resources from being overwhelmed
✅ **Graceful Degradation**: API continues processing accepted requests while rejecting excess traffic
✅ **Predictable Behavior**: Returns standard 429 status code when limits exceeded

## Testing

After deployment:
1. Test normal API requests continue to work
2. Generate high-volume traffic to verify 429 responses when limits exceeded
3. Monitor CloudWatch metrics for throttled requests

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added throttling parameters to API Gateway stage options
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Documented throttling configuration and behavior