### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Implement AWS WAF Rate Limiting for IP-Based Protection

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -8,6 +8,24 @@ Creates an [AWS Lambda](https://aws.amazon.com/lambda/) function writing to [Ama
 
 ![architecture](docs/architecture.png)
 
+## Security - AWS WAF Protection
+
+This stack implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** using AWS WAF for IP-based rate limiting.
+
+### WAF Configuration
+- **Rate Limit:** 2000 requests per 5 minutes per IP address
+- **Action:** Block requests exceeding the limit
+- **Monitoring:** CloudWatch metrics and alarms enabled
+
+### Protection Benefits
+- Prevents DDoS attacks from single IP addresses
+- Blocks malicious flooding attempts
+- Protects backend resources from abuse
+- Allows legitimate traffic while blocking excessive requests
+
+### Monitoring
+A CloudWatch alarm triggers when more than 100 requests are blocked in a single evaluation period, indicating potential attack or misconfiguration.
+
 ## Setup
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -10,6 +10,8 @@ from aws_cdk import (
     aws_ec2 as ec2,
     aws_iam as iam,
     aws_logs as logs,
+    aws_wafv2 as wafv2,
+    aws_cloudwatch as cloudwatch,
     Duration,
 )
 from constructs import Construct
@@ -98,8 +100,39 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             retention=logs.RetentionDays.ONE_YEAR,
         )
 
+        # Create WAF Web ACL with rate-based rule
+        web_acl = wafv2.CfnWebACL(
+            self,
+            "ApiWebAcl",
+            scope="REGIONAL",
+            default_action=wafv2.CfnWebACL.DefaultActionProperty(allow={}),
+            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                cloud_watch_metrics_enabled=True,
+                metric_name="ApiWebAclMetric",
+                sampled_requests_enabled=True
+            ),
+            rules=[
+                wafv2.CfnWebACL.RuleProperty(
+                    name="RateLimitRule",
+                    priority=1,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                            limit=2000,
+                            aggregate_key_type="IP"
+                        )
+                    ),
+                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="RateLimitRuleMetric",
+                        sampled_requests_enabled=True
+                    )
+                )
+            ]
+        )
+
         # Create API Gateway
-        apigw_.LambdaRestApi(
+        api = apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
@@ -118,4 +151,31 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
                     user=True,
                 ),
             ),
+        )
+
+        # Associate WAF Web ACL with API Gateway stage
+        wafv2.CfnWebACLAssociation(
+            self,
+            "WebAclAssociation",
+            resource_arn=api.deployment_stage.stage_arn,
+            web_acl_arn=web_acl.attr_arn
+        )
+
+        # CloudWatch alarm for blocked requests
+        cloudwatch.Alarm(
+            self,
+            "WafBlockedRequestsAlarm",
+            metric=cloudwatch.Metric(
+                namespace="AWS/WAFV2",
+                metric_name="BlockedRequests",
+                dimensions_map={
+                    "Rule": "RateLimitRule",
+                    "WebACL": web_acl.name,
+                    "Region": self.region
+                },
+                statistic="Sum"
+            ),
+            threshold=100,
+            evaluation_periods=1,
+            alarm_description="Alert when WAF blocks excessive requests from single IP"
         )


### PR DESCRIPTION
## Summary

This PR implements AWS WAF with IP-based rate limiting to address AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes protect the API from DDoS attacks, flooding, and abuse from individual malicious IP addresses.

Fixes #7

## Changes Made

### AWS WAF Web ACL with Rate-Based Rule
- Created regional WAF Web ACL for API Gateway protection
- Configured rate-based rule limiting requests to 2000 per 5 minutes per IP
- Enabled CloudWatch metrics and sampled request logging
- Blocks requests exceeding rate limit while allowing legitimate traffic

### WAF Association
- Associated WAF Web ACL with API Gateway deployment stage
- Ensures all API requests are evaluated by WAF rules

### CloudWatch Monitoring
- Created alarm for blocked requests (threshold: 100 requests)
- Monitors WAF metrics for security incident detection
- Enables proactive response to potential attacks

### Documentation
- Added "Security - AWS WAF Protection" section to README.md
- Documented rate limit configuration and protection benefits
- Explained monitoring and alarm functionality

## Well-Architected Framework Compliance

These changes implement REL05-BP02 IP-based rate limiting requirements, mitigating high risk of DDoS attacks and resource exhaustion from malicious sources.

✅ **DDoS Protection**: Blocks excessive requests from single IP addresses
✅ **Resource Protection**: Prevents individual sources from exhausting backend capacity
✅ **Security Monitoring**: CloudWatch alarms enable incident detection and response
✅ **Legitimate Traffic**: Rate limits allow normal usage while blocking abuse

## Testing

After deployment:
1. Verify normal API requests continue to work
2. Test rate limiting by sending >2000 requests from single IP in 5 minutes
3. Confirm blocked requests appear in WAF metrics
4. Verify CloudWatch alarm triggers when threshold exceeded

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added WAF Web ACL, rate-based rule, association, and CloudWatch alarm
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Documented WAF protection and monitoring