### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure Lambda Reserved Concurrency

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -8,6 +8,23 @@ Creates an [AWS Lambda](https://aws.amazon.com/lambda/) function writing to [Ama
 
 ![architecture](docs/architecture.png)
 
+## Lambda Concurrency Management
+
+This stack implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** using Lambda reserved concurrency.
+
+### Configuration
+- **Reserved Concurrency:** 50 concurrent executions
+- **Monitoring:** CloudWatch alarm for throttled invocations (threshold: 10)
+
+### Benefits
+- Prevents this function from consuming all account-level Lambda concurrency
+- Protects other Lambda functions in the same account and region
+- Acts as a throttling mechanism during traffic spikes
+- Ensures predictable resource allocation
+
+### Monitoring
+The CloudWatch alarm triggers when the function is throttled more than 10 times in an evaluation period, indicating capacity limits are being reached.
+
 ## Setup
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -10,6 +10,7 @@ from aws_cdk import (
     aws_ec2 as ec2,
     aws_iam as iam,
     aws_logs as logs,
+    aws_cloudwatch as cloudwatch,
     Duration,
 )
 from constructs import Construct
@@ -85,6 +86,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             timeout=Duration.minutes(5),
             tracing=lambda_.Tracing.ACTIVE,
             log_retention=logs.RetentionDays.ONE_YEAR,
+            reserved_concurrent_executions=50,
         )
 
         # grant permission to lambda to write to demo table
@@ -96,6 +98,16 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             self,
             "ApiGatewayAccessLogs",
             retention=logs.RetentionDays.ONE_YEAR,
+        )
+
+        # CloudWatch alarm for Lambda throttles
+        cloudwatch.Alarm(
+            self,
+            "LambdaThrottleAlarm",
+            metric=api_hanlder.metric_throttles(),
+            threshold=10,
+            evaluation_periods=1,
+            alarm_description="Alert when Lambda function is throttled"
         )
 
         # Create API Gateway


### PR DESCRIPTION
## Summary

This PR implements Lambda reserved concurrency to address AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes prevent this Lambda function from consuming all account-level concurrency quota, protecting other functions and enabling predictable resource allocation.

Fixes #8

## Changes Made

### Lambda Reserved Concurrency
- Configured `reserved_concurrent_executions=50` on the Lambda function
- Limits maximum concurrent executions to 50 instances
- Prevents account-level concurrency exhaustion

### CloudWatch Monitoring
- Created alarm for Lambda throttles (threshold: 10 invocations)
- Enables proactive detection when capacity limits are reached
- Helps identify when concurrency needs adjustment

### Documentation
- Added "Lambda Concurrency Management" section to README.md
- Documented reserved concurrency value and benefits
- Explained monitoring and alarm functionality

## Well-Architected Framework Compliance

These changes implement REL05-BP02 concurrency management requirements, mitigating medium risk of resource exhaustion and cascading failures across Lambda functions.

✅ **Account Protection**: Prevents consuming all Lambda concurrency in account/region
✅ **Predictable Allocation**: Guarantees available concurrency for this function
✅ **Isolation**: Protects other Lambda functions from being impacted
✅ **Throttling Mechanism**: Acts as rate limiter during traffic spikes

## Testing

After deployment:
1. Verify normal API requests continue to work
2. Monitor Lambda concurrent executions metric
3. Generate high-volume traffic to test throttling behavior
4. Verify CloudWatch alarm triggers when throttles occur

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added reserved concurrency and CloudWatch alarm
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Documented concurrency management