### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Implement Usage Plans and API Keys for Per-Client Rate Limiting

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/README.md
@@ -8,6 +8,39 @@ Creates an [AWS Lambda](https://aws.amazon.com/lambda/) function writing to [Ama
 
 ![architecture](docs/architecture.png)
 
+## API Authentication and Rate Limiting
+
+This stack implements AWS Well-Architected Framework best practice **REL05-BP02: Throttle requests** using API Gateway usage plans and API keys for per-client rate limiting.
+
+### Usage Plan Configuration
+- **Rate Limit:** 10 requests/second per API key
+- **Burst Limit:** 20 requests per API key
+- **Daily Quota:** 10,000 requests per API key
+
+### API Key Requirement
+All API requests must include a valid API key in the `x-api-key` header. Without a valid key, requests return `403 Forbidden`.
+
+### Retrieving API Key Value
+After deployment, retrieve the API key value:
+1. Note the API Key ID from the stack outputs
+2. Navigate to AWS API Gateway console → API Keys
+3. Click "Show" to reveal the API key value
+
+### Using the API
+Include the API key in all requests:
+```bash
+curl -X POST https://your-api-url/prod \
+  -H "x-api-key: your-api-key-value" \
+  -H "Content-Type: application/json" \
+  -d '{"year":"2023","title":"test","id":"123"}'
+```
+
+### Benefits
+- Per-client rate limiting prevents individual consumers from exhausting resources
+- Quota management enables fair usage across multiple API consumers
+- API key authentication provides basic access control
+- High-volume consumers can be identified and managed separately
+
 ## Setup
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.
@@ -70,7 +103,7 @@ $ cdk deploy --profile test
 ```
 
 ## After Deploy
-Navigate to AWS API Gateway console and test the API with below sample data 
+Navigate to AWS API Gateway console and test the API with below sample data (include your API key):
 ```json
 {
     "year":"2023", 

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -11,6 +11,7 @@ from aws_cdk import (
     aws_iam as iam,
     aws_logs as logs,
     Duration,
+    CfnOutput,
 )
 from constructs import Construct
 
@@ -99,10 +100,14 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
         )
 
         # Create API Gateway
-        apigw_.LambdaRestApi(
+        api = apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
+            api_key_source_type=apigw_.ApiKeySourceType.HEADER,
+            default_method_options=apigw_.MethodOptions(
+                api_key_required=True
+            ),
             deploy_options=apigw_.StageOptions(
                 tracing_enabled=True,
                 access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
@@ -118,4 +123,42 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
                     user=True,
                 ),
             ),
+        )
+
+        # Create usage plan
+        usage_plan = apigw_.UsagePlan(
+            self,
+            "ApiUsagePlan",
+            name="StandardUsagePlan",
+            throttle=apigw_.ThrottleSettings(
+                rate_limit=10,
+                burst_limit=20
+            ),
+            quota=apigw_.QuotaSettings(
+                limit=10000,
+                period=apigw_.Period.DAY
+            )
+        )
+
+        # Associate usage plan with API stage
+        usage_plan.add_api_stage(
+            stage=api.deployment_stage
+        )
+
+        # Create API key
+        api_key = apigw_.ApiKey(
+            self,
+            "ApiKey",
+            api_key_name="DefaultApiKey"
+        )
+
+        # Associate API key with usage plan
+        usage_plan.add_api_key(api_key)
+
+        # Output API key ID
+        CfnOutput(
+            self,
+            "ApiKeyId",
+            value=api_key.key_id,
+            description="API Key ID - retrieve value from AWS Console"
         )


### PR DESCRIPTION
## Summary

This PR implements API Gateway usage plans and API keys to address AWS Well-Architected Framework best practice REL05-BP02: Throttle requests. The changes enable per-client rate limiting, ensuring high-volume consumers cannot exhaust resources and impact other API users.

Fixes #6

## Changes Made

### API Key Requirement
- Configured API to require API keys via `api_key_source_type` and `api_key_required`
- All requests must include valid `x-api-key` header
- Returns `403 Forbidden` for requests without valid API key

### Usage Plan with Per-Client Throttling
- Created usage plan with rate limit: 10 requests/second per API key
- Configured burst limit: 20 requests per API key
- Set daily quota: 10,000 requests per API key
- Associated usage plan with API deployment stage

### API Key Management
- Created default API key for initial access
- Added CloudFormation output for API key ID
- API key value retrievable from AWS Console

### Documentation
- Added "API Authentication and Rate Limiting" section to README.md
- Documented usage plan configuration and limits
- Included instructions for retrieving and using API keys
- Updated sample requests to include API key header

## Well-Architected Framework Compliance

These changes implement REL05-BP02 per-client rate limiting requirements, mitigating medium risk of resource exhaustion from individual high-volume consumers.

✅ **Per-Client Isolation**: Individual consumers cannot exhaust shared resources
✅ **Fair Usage**: Quota management ensures equitable access across consumers
✅ **Consumer Identification**: API keys enable tracking and management of clients
✅ **Flexible Limits**: Different usage plans can be created for different consumer tiers

## Testing

After deployment:
1. Retrieve API key value from AWS Console using output API Key ID
2. Test requests with valid API key succeed
3. Test requests without API key return 403 Forbidden
4. Generate high-volume traffic from single API key to verify per-client throttling
5. Verify 429 responses when per-client limits exceeded

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added usage plan, API key, and API key requirement
- `python/apigw-http-api-lambda-dynamodb-python-cdk/README.md` - Documented API authentication and usage plan configuration